### PR TITLE
redis-and-denormalization-2

### DIFF
--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -34,6 +34,14 @@ class FriendshipViewSet(viewsets.GenericViewSet):
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
     def followings(self, request, pk):
         friendships = Friendship.objects.filter(from_user_id=pk).order_by('-created_at')
+
+        # Friendship.objects.filter(from_user_id=pk).prefetch_related('to_user')
+        # select * from friendships_table where from_user_id=123
+        # [4, 5, 6, 7]
+        # select * from user_table where id in (4, 5, 6, 7)
+        # prefetch会帮忙组织所有user info，塞进queryset产生每一个object中
+        # 后面serialize的时候会先去看有没有，有就不产生新查询
+
         page = self.paginate_queryset(friendships)
         serializer = FollowingSerializer(page, many=True, context={'request': request})
         return self.get_paginated_response(serializer.data)

--- a/friendships/models.py
+++ b/friendships/models.py
@@ -11,7 +11,7 @@ from utils.memcached_helper import MemcachedHelper
 
 # Create your models here.
 class Friendship(models.Model):
-    #粉丝
+    #博主，我自己关注的人
     from_user = models.ForeignKey(
         User,
         #on_delete会帮助我们在delete的时候不是真的删除而是变成null
@@ -19,7 +19,7 @@ class Friendship(models.Model):
         null=True,
         related_name="following_friendship_set",
     )
-
+    #关注我的粉丝
     to_user = models.ForeignKey(
         User,
         # on_delete会帮助我们在delete的时候不是真的删除而是变成null
@@ -32,9 +32,9 @@ class Friendship(models.Model):
 
     class Meta:
         index_together=(
-            #get all following users of curr user
+            #get all following users of curr user, 获取我关注的所有人
             ('from_user_id', 'created_at'),
-            #get all users I followed
+            #get all users I followed， 获取关注我的所有人
             ('to_user_id', 'created_at'),
         )
 

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -5,6 +5,7 @@ from newsfeeds.api.serializers import NewsFeedSerializer
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from utils.paginations import EndlessPagination
+from newsfeeds.services import NewsFeedService
 
 # Create your views here.
 class NewsFeedViewSet(viewsets.GenericViewSet):
@@ -14,8 +15,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
 
     def list(self, request):
         #NewsFeedSerializer需要的参数就是一个有关newsfeed的queryset
-        query = NewsFeed.objects.filter(user=self.request.user)
-        page = self.paginate_queryset(query)
+        # query = NewsFeed.objects.filter(user=self.request.user)
+
+        queryset = NewsFeedService.get_cached_newsfeeds(request.user.id)
+
+        page = self.paginate_queryset(queryset)
 
         #或者這麽寫
         #queryset = self.paginate_queryset(self.get_queryset())
@@ -27,5 +31,5 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         )
         return self.get_paginated_response(serializer.data)
 
-    def get_queryset(self):
-        return NewsFeed.objects.filter(user=self.request.user)
+    # def get_queryset(self):
+    #     return NewsFeed.objects.filter(user=self.request.user)

--- a/newsfeeds/listeners.py
+++ b/newsfeeds/listeners.py
@@ -1,0 +1,6 @@
+def push_newsfeed_to_cache(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    from newsfeeds.services import NewsFeedService
+    NewsFeedService.push_newsfeed_to_cache(instance)

--- a/newsfeeds/models.py
+++ b/newsfeeds/models.py
@@ -7,12 +7,16 @@ from tweets.models import Tweet
 
 from utils.memcached_helper import MemcachedHelper
 
+from newsfeeds.listeners import push_newsfeed_to_cache
+from django.db.models.signals import post_save, pre_delete
+
 # Create your models here.
 class NewsFeed(models.Model):
 
     #one user to store who can see this tweet
     #one tweet
     #created_at in order to quickly sort
+    #user指的是这个user可以看到这些tweets，
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True,)
     tweet = models.ForeignKey(Tweet, on_delete=models.SET_NULL, null=True,)
     created_at = models.DateTimeField(auto_now_add=True,)
@@ -31,3 +35,22 @@ class NewsFeed(models.Model):
     def cached_tweet(self):
         return MemcachedHelper.get_object_through_cache(Tweet, self.tweet_id)
 
+
+
+
+
+
+    #newsfeeds 的创建,not only through create, but also bulk create method.
+    #following: get_all_following 获取我自己关注的所有博主， from_user
+    #follower : get_all_follower 获取我的所有粉丝们  to_user
+    #fanout_to_followers : 对于我所有的粉丝们（followers），我们做一个list of newsfeeds，
+    # 里面存newsfeed：1.user=follower（粉丝），这表示的是粉丝们可以观看 2. tweet
+    #bulk create 不能触发listener中的signal，只能自己写触发机制了
+
+
+
+post_save.connect(push_newsfeed_to_cache, sender=NewsFeed)
+
+#newsfeed会被fanout给所有的粉丝
+#所以对于明星用户，我们不用fanout机制，做pull的机制，要不然会挺大的影响缓存
+#然后可以优化，通过不存储tweets的内容，存储tweets的id

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -7,6 +7,7 @@ from tweets.models import Tweet
 from newsfeeds.services import NewsFeedService
 from utils.decorators import required_params
 from utils.paginations import EndlessPagination
+from tweets.services import TweetService
 
 
 # Create your views here.
@@ -33,10 +34,10 @@ class TweetViewSet(viewsets.GenericViewSet,
     @required_params(params=['user_id'])
     def list(self, request, *args, **kwargs):
         #if no user in
-
-
-        queryset = self.get_queryset()
-        tweets = self.filter_queryset(queryset).order_by('-created_at')
+        user_id = request.query_params['user_id']
+        #
+        # queryset = self.get_queryset()
+        tweets = TweetService.get_cached_tweets(user_id=user_id)
         #comments = self.filter_queryset(queryset).order_by('created_at')
         # user_id = request.query_params['user_id']
         # tweets = Tweet.objects.filter(
@@ -44,8 +45,10 @@ class TweetViewSet(viewsets.GenericViewSet,
         #will return "list of dict" 每个list是serializer.data
         #tweets is queryset
 
+        #现在tweets是一个ordered list了，对ordered list进行pagination
+        #这里用的是我们自己的endlesspagination中的paginate_queryset方法，
+        #因为之前定义了pagination_class = EndlessPagination
         tweets = self.paginate_queryset(tweets)
-
 
         serializer = TweetSerializer(
             tweets,

--- a/tweets/listeners.py
+++ b/tweets/listeners.py
@@ -1,0 +1,6 @@
+def push_tweet_to_cache(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    from tweets.services import TweetService
+    TweetService.push_tweet_to_cache(instance)

--- a/tweets/services.py
+++ b/tweets/services.py
@@ -1,5 +1,7 @@
 from tweets.models import TweetPhoto
-
+from tweets.models import Tweet
+from twitter.cache import USER_TWEETS_PATTERN
+from utils.redis_helper import RedisHelper
 
 class TweetService(object):
 
@@ -17,3 +19,21 @@ class TweetService(object):
             #批量创建
             #bulk_create()
         TweetPhoto.objects.bulk_create(photos)
+
+    @classmethod
+    def get_cached_tweets(cls, user_id):
+
+        #  django queryset is lazy loading, 即使在这里filter了，但没有真正访问的时候，都不会触发DB查询
+        queryset = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+        key = USER_TWEETS_PATTERN.format(user_id=user_id)
+
+        return RedisHelper.load_objects(key, queryset)
+
+    @classmethod
+    def push_tweet_to_cache(cls, tweet):
+        queryset = Tweet.objects.filter(user_id=tweet.user_id).order_by('-created_id')
+        key = USER_TWEETS_PATTERN.format(user_id=tweet.user_id)
+
+        RedisHelper.push_objects(key, tweet, queryset)
+
+

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -12,14 +12,18 @@ class EndlessPagination(BasePagination):
 
     def to_html(self):
         pass
-
+        # 用reverse_ordered_list因为按照created_at 进行倒序的
     def paginate_ordered_list(self, reverse_ordered_list, request):
+
+        #删除的话就是外面讨一个while，去找一下看看有没有tweets被标记删除，如果有就去掉
+
+
         if 'created_at__gt' in request.query_params:
             # 兼容 iso 格式和 int 格式的时间戳
             try:
                 created_at__gt = int(request.query_params['created_at__gt'])
             except ValueError:
-
+            #解析把string解析成为date date格式
                 created_at__gt = parser.isoparse(request.query_params['created_at__gt'])
             objects = []
             for obj in reverse_ordered_list:
@@ -48,7 +52,14 @@ class EndlessPagination(BasePagination):
         self.has_next_page = len(reverse_ordered_list) > index + self.page_size
         return reverse_ordered_list[index: index + self.page_size]
 
+
+
     def paginate_queryset(self, queryset, request, view=None):
+
+        if type(queryset) == list:
+            return self.paginate_ordered_list(queryset, request)
+
+
             # created_at__gt 用于下拉刷新的时候加载最新的内容进来
             # 为了简便起见，下拉刷新不做翻页机制，直接加载所有更新的数据
             # 因为如果数据很久没有更新的话，不会采用下拉刷新的方式进行更新，而是重新加载最新的数据

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -1,0 +1,62 @@
+#功能是查询redis如果没有就去DB 最后结果是取出来相对应的object
+
+from django.conf import settings
+#from django_hbase.models import HBaseModel
+from utils.redis_client import RedisClient
+from utils.redis_serializer import DjangoModelSerializer
+    # , HBaseModelSerializer
+
+class RedisHelper:
+
+    # cache miss
+    @classmethod
+    def _load_iobjects_to_cache(cls, key, objects):
+        conn = RedisClient.get_cnonection()
+        serialized_list = []
+
+        for object in objects:
+            serialized_data = DjangoModelSerializer.serialize(object)
+            serialized_list.append(serialized_data)
+
+        if serialized_list:
+            #     * rep push one by one
+            conn.rpush(key, *serialized_list)
+            conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+
+
+
+    @classmethod
+    def load_objects(cls, key, queryset):
+        conn = RedisClient.get_cnonection()
+
+        if conn.exists(key):
+            #cache hit
+            #lrange是从左到右取出key对应value(list)
+            serialized_list = conn.lrange(key, 0, -1)
+            objects = []
+
+            for serialized_data in serialized_list:
+                deserialized_object = DjangoModelSerializer.deserialize(serialized_data)
+                objects.append(deserialized_object)
+
+            return objects
+
+        #cache miss
+        #需要写入cache
+        cls._load_iobjects_to_cache(key, queryset)
+
+
+    #load出来的时候 出来的是原本的objects data
+
+
+    #push进去的时候 实际进去的是一个serialized过的object data
+
+
+    @classmethod
+    def push_objects(cls, key, object, queryset):
+        conn = RedisClient.get_cnonection()
+        if not conn.exists(key):
+            cls._load_iobjects_to_cache(key, queryset)
+            return
+        serialized_data = DjangoModelSerializer.serialize(object)
+        conn.lpush(key, serialized_data)


### PR DESCRIPTION
newsfeed 和 tweet的 redis cache path:
1. newsfeed views中，get_cached_newsfeeds来获取
2. 实际services中 get_cached_tweets出力
3. 调用 helper的load_objects
4. 可能还会用到_load_iobjects_to_cache如果出现cache miss的话

新创建一个tweet会同时新建很多个newsfeed，这时候是用的listener，和serivces中push_newsfeed_to_cache。 
具体入口函数用的是newsfeed的model中  “post_save.connect(push_newsfeed_to_cache, sender=NewsFeed)”

TWEET也是同样的方式


